### PR TITLE
Fixing passwords with special chars and postgres startup

### DIFF
--- a/charts/kobotoolbox/Chart.yaml
+++ b/charts/kobotoolbox/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: kobotoolbox
-version: 0.2.7
+version: 0.2.8
 description: KoboToolbox field data collection solution
 home: https://www.kobotoolbox.org/
 icon: https://avatars.githubusercontent.com/u/5543677?s=400&v=4

--- a/charts/kobotoolbox/templates/_helpers.tpl
+++ b/charts/kobotoolbox/templates/_helpers.tpl
@@ -3,11 +3,11 @@
 # TODO: move passwords to secrets...
 
 {{- define "kc_dburl" -}}
-postgis://{{ .Values.postgresql.postgresqlUsername }}:{{ .Values.postgresql.postgresqlPassword }}@{{ .Release.Name }}-postgresql:5432/{{ .Values.postgresql.kobocatDatabase }}
+postgis://{{ .Values.postgresql.postgresqlUsername }}:{{ urlquery .Values.postgresql.postgresqlPassword }}@{{ .Release.Name }}-postgresql:5432/{{ .Values.postgresql.kobocatDatabase }}
 {{- end -}}
 
 {{- define "kpi_dburl" -}}
-postgis://{{ .Values.postgresql.postgresqlUsername }}:{{ .Values.postgresql.postgresqlPassword }}@{{ .Release.Name }}-postgresql:5432/{{ .Values.postgresql.kpiDatabase }}
+postgis://{{ .Values.postgresql.postgresqlUsername }}:{{ urlquery .Values.postgresql.postgresqlPassword }}@{{ .Release.Name }}-postgresql:5432/{{ .Values.postgresql.kpiDatabase }}
 {{- end -}}
 
 {{- define "internal_domain" -}}
@@ -35,19 +35,19 @@ kobo.local
 {{- end -}}
 
 {{- define "redis_url_session" -}}
-redis://:{{ .Values.global.redis.password }}@{{ .Release.Name }}-rediscache-master:6379/2
+redis://:{{ urlquery .Values.global.redis.password }}@{{ .Release.Name }}-rediscache-master:6379/2
 {{- end -}}
 
 {{- define "redis_url_lock" -}}
-redis://:{{ .Values.global.redis.password }}@{{ .Release.Name }}-rediscache-master:6379/3
+redis://:{{ urlquery .Values.global.redis.password }}@{{ .Release.Name }}-rediscache-master:6379/3
 {{- end -}}
 
 {{- define "redis_url_kobobroker" -}}
-redis://:{{ .Values.global.redis.password }}@{{ .Release.Name }}-redismain-master:6379/2
+redis://:{{ urlquery .Values.global.redis.password }}@{{ .Release.Name }}-redismain-master:6379/2
 {{- end -}}
 
 {{- define "redis_url_kpibroker" -}}
-redis://:{{ .Values.global.redis.password }}@{{ .Release.Name }}-redismain-master:6379/1
+redis://:{{ urlquery .Values.global.redis.password }}@{{ .Release.Name }}-redismain-master:6379/1
 {{- end -}}
 
 {{- define "env_general" -}}

--- a/charts/kobotoolbox/templates/kobo-postgres-init-scripts.yaml
+++ b/charts/kobotoolbox/templates/kobo-postgres-init-scripts.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-postgres-init-scripts
+  namespace: {{ .Release.Namespace }}
+data:
+  init.sql: |
+    ALTER USER "{{ .Values.postgresql.postgresqlUsername }}" WITH SUPERUSER;
+    CREATE DATABASE "{{ .Values.postgresql.kobocatDatabase }}" OWNER "{{ .Values.postgresql.postgresqlUsername }}";
+    \c "{{ .Values.postgresql.kobocatDatabase }}"
+    CREATE EXTENSION IF NOT EXISTS postgis;
+    CREATE EXTENSION IF NOT EXISTS postgis_topology;
+    CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
+    CREATE EXTENSION IF NOT EXISTS postgis_tiger_geocoder;
+    CREATE DATABASE "{{ .Values.postgresql.kpiDatabase }}" OWNER "{{ .Values.postgresql.postgresqlUsername }}";
+    \c "{{ .Values.postgresql.kpiDatabase }}"
+    CREATE EXTENSION IF NOT EXISTS postgis;
+    CREATE EXTENSION IF NOT EXISTS postgis_topology;
+    CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
+    CREATE EXTENSION IF NOT EXISTS postgis_tiger_geocoder;

--- a/charts/kobotoolbox/values.yaml
+++ b/charts/kobotoolbox/values.yaml
@@ -264,8 +264,10 @@ postgresql:
 
   # TODO: support external db
   # For now we only support a db installed with a subchart
+  initdbScriptsConfigMap: "{{ .Release.Name }}-postgres-init-scripts"
+  initdbUser: postgres
+  initdbPassword:  ${postgresqlPostgresPassword}
 
   postgresqlPostgresPassword: admin
   postgresqlUsername: postgres
   postgresqlPassword: kobo
-  initdbScriptsConfigMap: "{{ .Release.Name }}-postgres-init"


### PR DESCRIPTION
## Proposed changes
Due to special characters in password and changing usernames, we faced issues trying to use the kobo chart. 
To fix it, some little changes were necessary:

- Passwords with special characters were not working in the DB URLs. They have been encoded in the template.
- During startup, db extensions are not created due to super user permissions.   initdbUser &  initdbPassword values were added in values.yaml to solve it.
- Renaming of Postgres init script to kobo-postgres-init-scripts.yaml in order standardizing config map names.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [X] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [X] I have squashed my commits into logic units.
- [X] I have described the changes in the commit messages.

## Other information

I am available to discuss the changes.