### PR TITLE
Bugfix/mongodb replicaset

### DIFF
--- a/charts/growthbook/templates/_helpers.tpl
+++ b/charts/growthbook/templates/_helpers.tpl
@@ -80,7 +80,11 @@ Create the name of the service account to use
 
 {{- define "growthbook.mongo.uri" -}}
 {{- if .Values.mongodb.enabled -}}
-{{- printf "mongodb://%s:%s@%s:27017/%s" .Values.mongodb.auth.username  .Values.mongodb.auth.password (include "growthbook.mongo.service" .) .Values.mongodb.auth.database }}
+{{- if ne .Values.mongodb.architecture "replicaset" -}}
+{{- printf "mongodb://%s:%s@%s:27017/%s" .Values.mongodb.auth.username .Values.mongodb.auth.password (include "growthbook.mongo.service" .) .Values.mongodb.auth.database }}
+{{- else }}
+{{- printf "mongodb://%s:%s@%s:27017/%s?replicaSet=%s" .Values.mongodb.auth.username .Values.mongodb.auth.password (include "growthbook.mongo.service" .) .Values.mongodb.auth.database .Values.mongodb.replicaSetName }}
+{{- end }}
 {{- else }}
 {{- .Values.growthbook.externalMongodbUri }}
 {{- end }}

--- a/charts/growthbook/templates/_helpers.tpl
+++ b/charts/growthbook/templates/_helpers.tpl
@@ -74,9 +74,13 @@ Create the name of the service account to use
 {{- end }}
 {{- end }}
 
+{{- define "growthbook.mongo.service" -}}
+{{ include "growthbook.fullname" . }}-{{- if eq .Values.mongodb.architecture "replicaset" -}}mongodb-headless{{- else -}}mongo{{- end -}}
+{{- end }}
+
 {{- define "growthbook.mongo.uri" -}}
 {{- if .Values.mongodb.enabled -}}
-{{- printf "mongodb://%s:%s@%s-mongodb:27017/%s" .Values.mongodb.auth.username  .Values.mongodb.auth.password (include "growthbook.fullname" .) .Values.mongodb.auth.database }}
+{{- printf "mongodb://%s:%s@%s:27017/%s" .Values.mongodb.auth.username  .Values.mongodb.auth.password (include "growthbook.mongo.service" .) .Values.mongodb.auth.database }}
 {{- else }}
 {{- .Values.growthbook.externalMongodbUri }}
 {{- end }}
@@ -86,5 +90,5 @@ Create the name of the service account to use
 - name: MONGODB_PORT
   value: '27017'
 - name: MONGODB_HOST
-  value: {{ include "growthbook.fullname" . }}-mongodb
+  value: {{ include "growthbook.mongo.service" . }}
 {{- end }}

--- a/charts/growthbook/templates/configmap.yaml
+++ b/charts/growthbook/templates/configmap.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+data:
+  livenessprobe-exec.sh: |
+    #!/bin/bash
+    CURL_HTTP=$(curl -s -o /dev/null -w "%{http_code}" -XPOST http://localhost:3100/auth/refresh)
+    CURL_EXIT=$?
+    if [ $CURL_EXIT -eq 0 ] && [ $CURL_HTTP -eq 200 ]; then
+      echo "Liveness check probe OK"
+      exit 0
+    else
+      echo "Liveness check probe ERROR - curl exit code $CURL_EXIT, API HTTP code $CURL_HTTP"
+      exit 1
+    fi
+
+kind: ConfigMap
+metadata:
+  name: {{ include "growthbook.fullname" . }}-livenessprobe-exec

--- a/charts/growthbook/templates/deployment.yaml
+++ b/charts/growthbook/templates/deployment.yaml
@@ -45,6 +45,17 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          lifecycle:
+            postStart:
+              exec:
+                command: ["/bin/sh", "-c", "apt-get update && apt-get install curl -y"]
+          livenessProbe:
+            exec:
+              command:
+              - bash
+              - /usr/local/src/growthbook-helm/livenessprobe-exec.sh
+            initialDelaySeconds: 30
+            periodSeconds: 5
           env:
             {{- range $key, $value := .Values.growthbook.extraEnvVars }}
             - name: {{ $key }}
@@ -89,6 +100,8 @@ spec:
               value: {{ .Values.growthbook.datasource.google.clientSecret }}
             {{ end }}
           volumeMounts:
+            - name: {{ include "growthbook.fullname" . }}-livenessprobe-exec
+              mountPath: /usr/local/src/growthbook-helm
             - name: {{ include "growthbook.fullname" . }}
               mountPath: {{ .Values.volume.mountPath }}
           ports:
@@ -103,6 +116,9 @@ spec:
       nodeSelector:
         {{- toYaml .Values.nodeSelector | nindent 8 }}
       volumes:
+        - name: {{ include "growthbook.fullname" . }}-livenessprobe-exec
+          configMap:
+            name: {{ include "growthbook.fullname" . }}-livenessprobe-exec
         - name: {{ include "growthbook.fullname" . }}
           {{ include "growthbook.pvc" . }}
       {{- with .Values.affinity }}

--- a/charts/growthbook/values.yaml
+++ b/charts/growthbook/values.yaml
@@ -122,6 +122,8 @@ mongodb:
     username: growthbook
     password: growthbook
     database: growthbook-db
+  architecture: standalone
+  replicaSetName: rs0
   initdbScripts:
     grant-role.js: |
       db = db.getSiblingDB('{{ .Values.auth.database }}')


### PR DESCRIPTION
## Proposed changes

It is not possible to install `growthbook` chart when using `mongodb.architecture=replicaset`.

When using `replicaset` MongoDB service is no longer `release-name-mongo`, but `release-name-mongo-headless`.

I have added new template `growthbook.mongo.service` and included it in `growthbook.mongo.uri` and `growthbook.mongo.env`.

Another thing is that when using replicaset there is elevated risk of MongoDB connection problems from which GrowthBook sometimes does not handle. That why it is essential to add GrowthBook API liveness probe.

## Checklist

- [X] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [X] I have added documentation to describe my feature.
- [X] I have squashed my commits into logic units.
- [X] I have described the changes in the commit messages.
