### PR TITLE
Fix growthbook chart ingress secret name

### DIFF
--- a/charts/growthbook/Chart.yaml
+++ b/charts/growthbook/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.14
+version: 0.1.15
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/growthbook/README.md
+++ b/charts/growthbook/README.md
@@ -1,6 +1,6 @@
 # growthbook
 
-![Version: 0.1.14](https://img.shields.io/badge/Version-0.1.14-informational?style=flat-square)
+![Version: 0.1.15](https://img.shields.io/badge/Version-0.1.15-informational?style=flat-square)
 
 A Helm chart for Growthbook
 

--- a/charts/growthbook/README.md
+++ b/charts/growthbook/README.md
@@ -73,6 +73,7 @@ $ helm install my-release one-acre-fund/growthbook
 | ingress.appOriginName | string | `"my-app-origin.io"` |  |
 | ingress.enabled | bool | `false` |  |
 | ingress.name | string | `"growthbook-ingress"` |  |
+| ingress.secretName | string | `"growthbook-tls"` |  |
 | mongodb.architecture | string | `"standalone"` |  |
 | mongodb.auth.database | string | `"growthbook-db"` |  |
 | mongodb.auth.password | string | `"growthbook"` |  |

--- a/charts/growthbook/templates/ingress.yaml
+++ b/charts/growthbook/templates/ingress.yaml
@@ -31,5 +31,5 @@ spec:
     - hosts:
         - {{ .Values.ingress.appOriginName }}
         - {{ .Values.ingress.apiHostName }}
-      secretName: {{ .secretName }}
+      secretName: {{ .Values.ingress.secretName }}
 {{- end -}}

--- a/charts/growthbook/values.yaml
+++ b/charts/growthbook/values.yaml
@@ -112,6 +112,7 @@ service:
 ingress:
   enabled: false
   name: growthbook-ingress
+  secretName: growthbook-tls
   annotations:
     kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"


### PR DESCRIPTION
# Proposed changes

This PR fixes the following issue: https://github.com/one-acre-fund/oaf-public-charts/issues/161.
The ingress template has an unset variable for the secretName which is causing this problem.


## Checklist

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information

