### PR TITLE
chore: Add GitHub Pages workflow for Jekyll site deployment

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,54 @@
+# Sample workflow for building and deploying a Jekyll site to GitHub Pages
+name: Deploy Jekyll with GitHub Pages dependencies preinstalled
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["main"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.2.1
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5.0.0
+
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@v1.0.13
+        with:
+          source: ./
+          destination: ./root
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3.0.1
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4.0.5


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for automating the build and deployment of a Jekyll site to GitHub Pages. The workflow is triggered on pushes to the `main` branch and can also be manually triggered from the Actions tab.

Key changes include:

* Workflow configuration:
  * Created a new workflow named "Deploy Jekyll with GitHub Pages dependencies preinstalled" in `.github/workflows/gh-pages.yml`.
  * Configured the workflow to trigger on pushes to the `main` branch and manually via `workflow_dispatch`.
  * Set permissions for the `GITHUB_TOKEN` to allow deployment to GitHub Pages.
  * Added concurrency control to allow only one concurrent deployment without canceling in-progress runs.

* Build and deployment jobs:
  * Defined a `build` job that checks out the code, sets up Pages, builds the site with Jekyll, and uploads the artifact.
  * Defined a `deploy` job that deploys the built site to GitHub Pages, requiring the `build` job to complete first.