### PR TITLE
chore: Update destination path for GitHub Pages workflow

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/jekyll-build-pages@v1.0.13
         with:
           source: ./
-          destination: ./root
+          destination: ./site
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3.0.1


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/gh-pages.yml` file. The change updates the `destination` path for the Jekyll build action to ensure the site is built in the correct directory.

* [`.github/workflows/gh-pages.yml`](diffhunk://#diff-c04119feaeffc2c216f069aec66797f2f839a2074287060698e3a2440dec8d45L39-R39): Changed the `destination` from `./root` to `./site` in the Jekyll build action.