### PR TITLE
chore: Update version to 0.3.0 in nocodb chart

### DIFF
--- a/charts/mautic/Chart.yaml
+++ b/charts/mautic/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "v4-apache"
 description: A Helm chart for Mautic, a marketing automation tool
 name: mautic
-version: 0.1.6
+version: 0.1.7
 icon: https://secure.gravatar.com/avatar/a946d764bc1e4a7a39664099febfc9b2.png?s=400
 home: https://www.mautic.org/
 keywords:

--- a/charts/mautic/README.md
+++ b/charts/mautic/README.md
@@ -1,6 +1,6 @@
 # mautic
 
-![Version: 0.1.5](https://img.shields.io/badge/Version-0.1.5-informational?style=flat-square)
+![Version: 0.1.6](https://img.shields.io/badge/Version-0.1.6-informational?style=flat-square)
 
 A Helm chart for Mautic, a marketing automation tool
 

--- a/charts/mautic/README.md
+++ b/charts/mautic/README.md
@@ -1,6 +1,6 @@
 # mautic
 
-![Version: 0.1.6](https://img.shields.io/badge/Version-0.1.6-informational?style=flat-square)
+![Version: 0.1.7](https://img.shields.io/badge/Version-0.1.7-informational?style=flat-square)
 
 A Helm chart for Mautic, a marketing automation tool
 

--- a/charts/nocodb/Chart.yaml
+++ b/charts/nocodb/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/nocodb/README.md
+++ b/charts/nocodb/README.md
@@ -1,8 +1,12 @@
 # nocodb
 
-![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square)
+
+
+![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) 
 
 A Helm chart for Kubernetes
+
+
 
 ## Maintainers
 
@@ -19,8 +23,8 @@ A Helm chart for Kubernetes
 [nocodb](https://www.nocodb.com/) is an open source no-code platform to build and manage your data-driven applications.
 
 ```console
-helm repo add one-acre-fund https://one-acre-fund.github.io/oaf-public-charts
-helm install my-release one-acre-fund/nocodb
+$ helm repo add one-acre-fund https://one-acre-fund.github.io/oaf-public-charts
+$ helm install my-release one-acre-fund/nocodb
 ```
 
 ## Requirements


### PR DESCRIPTION
This pull request includes updates to the version numbers and documentation for the `mautic` and `nocodb` Helm charts. The most important changes are the version bumps and the improvements in the `nocodb` README file.

Version updates:

* [`charts/mautic/README.md`](diffhunk://#diff-033d7e1da486f36e5fedda7574345d3a26b7c18c53c83d4b48a67b8e967a7af9L3-R3): Updated the version badge from `0.1.5` to `0.1.6`.
* [`charts/nocodb/Chart.yaml`](diffhunk://#diff-41b537b84129195eaf7a36558c32b383f08d2acca8bcbc4a5ade6d226aa8ecfcL18-R18): Updated the chart version from `0.1.1` to `0.3.0`.
* [`charts/nocodb/README.md`](diffhunk://#diff-730388c2f3d16c4d940391f1399dbe4edb2657881ccba39181ef9564f5fc64daL3-R10): Updated the version badge from `0.1.1` to `0.3.0`.

Documentation improvements:

* [`charts/nocodb/README.md`](diffhunk://#diff-730388c2f3d16c4d940391f1399dbe4edb2657881ccba39181ef9564f5fc64daL22-R27): Added spacing and improved the Helm command formatting for better readability.