### PR TITLE
Update NocoDB Helm Chart: Secret Management Enhancements

### DIFF
--- a/charts/nocodb/Chart.yaml
+++ b/charts/nocodb/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.1
+version: 0.3.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/nocodb/README.md
+++ b/charts/nocodb/README.md
@@ -2,7 +2,7 @@
 
 
 
-![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) 
+![Version: 0.3.2](https://img.shields.io/badge/Version-0.3.2-informational?style=flat-square) 
 
 A Helm chart for Kubernetes
 
@@ -82,6 +82,8 @@ $ helm install my-release one-acre-fund/nocodb
 | externalDatabase.postgresqlPostgresPassword | string | `""` |  |
 | externalDatabase.postgresqlPostgresUser | string | `"nocodb_admin_user"` |  |
 | externalDatabase.user | string | `"nocodb_user"` |  |
+| extraEnv | list | `[]` |  |
+| extraEnvSecrets | list | `[]` |  |
 | fullnameOverride | string | `""` |  |
 | global.defaultStorageClass | string | `""` |  |
 | global.imagePullSecrets | list | `[]` |  |
@@ -99,11 +101,6 @@ $ helm install my-release one-acre-fund/nocodb
 | ingress.hosts[0].paths[0].path | string | `"/"` |  |
 | ingress.hosts[0].paths[0].pathType | string | `"ImplementationSpecific"` |  |
 | ingress.tls | list | `[]` |  |
-| jwt.create | bool | `true` |  |
-| jwt.existingSecretKey | string | `""` |  |
-| jwt.existingSecretName | string | `""` |  |
-| jwt.name | string | `""` |  |
-| jwt.secret | string | `""` |  |
 | livenessProbe.failureThreshold | int | `3` |  |
 | livenessProbe.httpGet.path | string | `"/api/v1/health"` |  |
 | livenessProbe.httpGet.port | string | `"http"` |  |

--- a/charts/nocodb/templates/_helpers.tpl
+++ b/charts/nocodb/templates/_helpers.tpl
@@ -181,7 +181,7 @@ Add environment variables to configure database values
     {{- end -}}
 {{- end -}}
 
-{{- define "nocodb.adminSecretName" -}}
+{{- define "nocodb.admin.secretName" -}}
   {{- if .Values.admin.existingSecretName -}}
     {{- printf "%s" .Values.admin.existingSecretName -}}
   {{- else -}}
@@ -189,7 +189,7 @@ Add environment variables to configure database values
   {{- end -}}
 {{- end -}}
 
-{{- define "nocodb.adminEmailKey" -}}
+{{- define "nocodb.admin.emailKey" -}}
     {{- if .Values.admin.existingSecretEmailKey -}}
         {{- printf "%s" .Values.admin.existingSecretEmailKey -}}
     {{- else -}}
@@ -197,7 +197,7 @@ Add environment variables to configure database values
     {{- end -}}
 {{- end -}}
 
-{{- define "nocodb.adminPasswordKey" -}}
+{{- define "nocodb.admin.passwordKey" -}}
     {{- if .Values.admin.existingSecretPasswordKey -}}
         {{- printf "%s" .Values.admin.existingSecretPasswordKey -}}
     {{- else -}}
@@ -205,7 +205,7 @@ Add environment variables to configure database values
     {{- end -}}
 {{- end -}}
 
-{{- define "nocodb.smtpSecretName" -}}
+{{- define "nocodb.smtp.secretName" -}}
   {{- if .Values.smtp.existingSecretName -}}
     {{- printf "%s" .Values.smtp.existingSecretName -}}
   {{- else -}}
@@ -213,18 +213,61 @@ Add environment variables to configure database values
   {{- end -}}
 {{- end -}}
 
-{{- define "nocodb.smtpSecretPasswordKey" -}}
+{{- define "nocodb.smtp.secretPasswordKey" -}}
     {{- if .Values.smtp.existingSecretPasswordKey -}}
         {{- printf "%s" .Values.smtp.existingSecretPasswordKey -}}
     {{- else -}}
-        {{- print "password" -}}
+        {{- print "smtp-password" -}}
     {{- end -}}
 {{- end -}}
 
-{{- define "nocodb.smtpSecretUsernameKey" -}}
+{{- define "nocodb.smtp.secretUsernameKey" -}}
     {{- if .Values.smtp.existingSecretUsernameKey -}}
         {{- printf "%s" .Values.smtp.existingSecretUsernameKey -}}
     {{- else -}}
-        {{- print "username" -}}
+        {{- print "smtp-username" -}}
+    {{- end -}}
+{{- end -}}
+
+{{/*
+Get the credentials secret.
+*/}}
+{{- define "nocodb.minio.secretName" -}}
+{{- if .Values.minio.auth.existingSecret -}}
+    {{- printf "%s" (tpl .Values.minio.auth.existingSecret $) -}}
+{{- else -}}
+    {{- printf "%s" (include "nocodb.minio.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "nocodb.minio.rootUserKey" -}}
+    {{- if .Values.minio.auth.existingSecretRootUserKey -}}
+        {{- printf "%s" .Values.minio.auth.existingSecretRootUserKey -}}
+    {{- else -}}
+        {{- print "root-user" -}}
+    {{- end -}}
+{{- end -}}
+
+{{- define "nocodb.minio.rootPasswordKey" -}}
+    {{- if .Values.minio.auth.existingSecretRootPasswordKey -}}
+        {{- printf "%s" .Values.minio.auth.existingSecretRootPasswordKey -}}
+    {{- else -}}
+        {{- print "root-password" -}}
+    {{- end -}}
+{{- end -}}
+
+{{- define "nocodb.redis.secretName" -}}
+{{- if .Values.redis.auth.existingSecret -}}
+    {{- printf "%s" (tpl .Values.redis.auth.existingSecret $) -}}
+{{- else -}}
+    {{- printf "%s" (include "nocodb.redis.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "nocodb.redis.passwordKey" -}}
+    {{- if .Values.redis.auth.existingSecretKey -}}
+        {{- printf "%s" .Values.redis.auth.existingSecretKey -}}
+    {{- else -}}
+        {{- print "redis-password" -}}
     {{- end -}}
 {{- end -}}

--- a/charts/nocodb/templates/admin-user-secert.yaml
+++ b/charts/nocodb/templates/admin-user-secert.yaml
@@ -1,8 +1,8 @@
-{{ if .Values.admin.create }}
+{{ if and .Values.admin.create (not (eq .Values.admin.email "")) (not (eq .Values.admin.password "")) }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "nocodb.adminSecretName" . }}
+  name: {{ include "nocodb.admin.secretName" . }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
   {{- if .Values.commonAnnotations }}
@@ -10,6 +10,6 @@ metadata:
   {{- end }}
 type: Opaque
 data:
-  {{ include "nocodb.adminEmailKey" . }}: {{ .Values.admin.email | b64enc | quote }}
-  {{ include "nocodb.adminPasswordKey" . }}: {{ .Values.admin.password | b64enc | quote }}
+  {{ include "nocodb.admin.emailKey" . }}: {{ .Values.admin.email | b64enc | quote }}
+  {{ include "nocodb.admin.passwordKey" . }}: {{ .Values.admin.password | b64enc | quote }}
 {{- end }}

--- a/charts/nocodb/templates/deployment.yaml
+++ b/charts/nocodb/templates/deployment.yaml
@@ -114,13 +114,13 @@ spec:
             - name: NC_S3_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "nocodb.fullname" . }}-minio
-                  key: root-user
+                  name: {{ include "nocodb.minio.secretName" . }}
+                  key: {{ include "nocodb.minio.rootPasswordKey" . }}
             - name: NC_S3_ACCESS_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "nocodb.fullname" . }}-minio
-                  key: root-password
+                  name: {{ include "nocodb.minio.secretName" . }}
+                  key: {{ include "nocodb.minio.rootPasswordKey" . }}
             - name: NC_S3_FORCE_PATH_STYLE
               value: "true"
             {{- end }}
@@ -128,8 +128,8 @@ spec:
             - name: NC_REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "nocodb.fullname" . }}-redis
-                  key: redis-password
+                  name: {{ include "nocodb.redis.secretName" . }}
+                  key: {{ include "nocodb.redis.passwordKey" . }}
             - name: NC_REDIS_URL
               value: "redis://:$(NC_REDIS_PASSWORD)@{{ template "nocodb.redis.fullname" . }}-master:{{ .Values.redis.master.service.ports.redis }}"
             {{- end }}
@@ -137,13 +137,13 @@ spec:
             - name: NC_ADMIN_EMAIL
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "nocodb.adminSecretName" . }}
-                  key: {{ include "nocodb.adminEmailKey" . }}
+                  name: {{ include "nocodb.admin.secretName" . }}
+                  key: {{ include "nocodb.admin.emailKey" . }}
             - name: NC_ADMIN_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "nocodb.adminSecretName" . }}
-                  key: {{ include "nocodb.adminPasswordKey" . }}
+                  name: {{ include "nocodb.admin.secretName" . }}
+                  key: {{ include "nocodb.admin.passwordKey" . }}
             {{- end }}
             {{- if and .Values.smtp.enabled (or (not (eq .Values.smtp.password "")) .Values.smtp.existingSecretName) }}
             - name: NC_SMTP_HOST
@@ -155,13 +155,13 @@ spec:
             - name: NC_SMTP_USERNAME
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "nocodb.smtpSecretName" . }}
-                  key: {{ include "nocodb.smtpSecretUsernameKey" . }}
+                  name: {{ include "nocodb.smtp.secretName" . }}
+                  key: {{ include "nocodb.smtp.secretUsernameKey" . }}
             - name: NC_SMTP_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "nocodb.smtpSecretName" . }}
-                  key: {{ include "nocodb.smtpSecretPasswordKey" . }}
+                  name: {{ include "nocodb.smtp.secretName" . }}
+                  key: {{ include "nocodb.smtp.secretPasswordKey" . }}
             - name: NC_SMTP_FROM
               value: {{ .Values.smtp.from | quote }}
             - name: NC_SMTP_IGNORE_TLS

--- a/charts/nocodb/templates/smtp-secret.yaml
+++ b/charts/nocodb/templates/smtp-secret.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "nocodb.smtpSecretName" . }}
+  name: {{ include "nocodb.smtp.secretName" . }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
   {{- if .Values.commonAnnotations }}
@@ -10,6 +10,6 @@ metadata:
   {{- end }}
 type: Opaque
 data:
-  {{ include "nocodb.smtpSecretUsernameKey" . }}: {{ .Values.smtp.username | b64enc | quote }}
-  {{ include "nocodb.smtpSecretPasswordKey" . }}: {{ .Values.smtp.password | b64enc | quote }}
+  {{ include "nocodb.smtp.secretUsernameKey" . }}: {{ .Values.smtp.username | b64enc | quote }}
+  {{ include "nocodb.smtp.secretPasswordKey" . }}: {{ .Values.smtp.password | b64enc | quote }}
 {{- end }}


### PR DESCRIPTION
This pull request includes several updates to the Helm chart for NocoDB, focusing on version bumping, documentation updates, and improvements to secret management. The most important changes include updating the chart version, adding new environment variables, and refining secret key references.

### Version and Documentation Updates:
* [`charts/nocodb/Chart.yaml`](diffhunk://#diff-41b537b84129195eaf7a36558c32b383f08d2acca8bcbc4a5ade6d226aa8ecfcL18-R18): Bumped chart version from `0.3.1` to `0.3.2`.
* [`charts/nocodb/README.md`](diffhunk://#diff-730388c2f3d16c4d940391f1399dbe4edb2657881ccba39181ef9564f5fc64daL5-R5): Updated the version badge to `0.3.2` and added new environment variables `extraEnv` and `extraEnvSecrets`.

### Secret Management Improvements:
* [`charts/nocodb/templates/_helpers.tpl`](diffhunk://#diff-418d97319d8305d1fb0eb042f1faa1c7a072d87f99e2c1508b71fbbf1a4f1ebaL184-R271): Renamed secret key definitions for better clarity and added new definitions for MinIO and Redis credentials.
* [`charts/nocodb/templates/admin-user-secert.yaml`](diffhunk://#diff-1056cce39daf9737fc575a94d63537980d25cc3edf003fb362991a6427234c7fL1-R14): Enhanced secret creation condition and updated secret key references.
* [`charts/nocodb/templates/deployment.yaml`](diffhunk://#diff-94600fa83e4adf02baa1f97ad0d29fb61a59707e2445890116187f6f72d4d896L117-R146): Updated secret key references for MinIO, Redis, and SMTP configurations.
* [`charts/nocodb/templates/smtp-secret.yaml`](diffhunk://#diff-f1212889d39ac321cf245afeb56db3182fcd1c5d648abdbba4f8f551e3a2dd64L5-R14): Updated SMTP secret key references for consistency.