### PR TITLE
Refactor nocodb template variable names for minio secret

### DIFF
--- a/charts/nocodb/Chart.yaml
+++ b/charts/nocodb/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.2
+version: 0.3.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/nocodb/README.md
+++ b/charts/nocodb/README.md
@@ -2,7 +2,7 @@
 
 
 
-![Version: 0.3.2](https://img.shields.io/badge/Version-0.3.2-informational?style=flat-square) 
+![Version: 0.3.3](https://img.shields.io/badge/Version-0.3.3-informational?style=flat-square) 
 
 A Helm chart for Kubernetes
 

--- a/charts/nocodb/templates/_helpers.tpl
+++ b/charts/nocodb/templates/_helpers.tpl
@@ -241,16 +241,16 @@ Get the credentials secret.
 {{- end -}}
 
 {{- define "nocodb.minio.rootUserKey" -}}
-    {{- if .Values.minio.auth.existingSecretRootUserKey -}}
-        {{- printf "%s" .Values.minio.auth.existingSecretRootUserKey -}}
+    {{- if .Values.minio.auth.rootUserSecretKey -}}
+        {{- printf "%s" .Values.minio.auth.rootUserSecretKey -}}
     {{- else -}}
         {{- print "root-user" -}}
     {{- end -}}
 {{- end -}}
 
 {{- define "nocodb.minio.rootPasswordKey" -}}
-    {{- if .Values.minio.auth.existingSecretRootPasswordKey -}}
-        {{- printf "%s" .Values.minio.auth.existingSecretRootPasswordKey -}}
+    {{- if .Values.minio.auth.rootPasswordSecretKey -}}
+        {{- printf "%s" .Values.minio.auth.rootPasswordSecretKey -}}
     {{- else -}}
         {{- print "root-password" -}}
     {{- end -}}


### PR DESCRIPTION
This pull request includes updates to the version number of the Helm chart and modifications to the handling of Minio credentials in the NocoDB Helm chart. The most important changes are listed below:

Version updates:
* [`charts/nocodb/Chart.yaml`](diffhunk://#diff-41b537b84129195eaf7a36558c32b383f08d2acca8bcbc4a5ade6d226aa8ecfcL18-R18): Updated the chart version from `0.3.2` to `0.3.3`.
* [`charts/nocodb/README.md`](diffhunk://#diff-730388c2f3d16c4d940391f1399dbe4edb2657881ccba39181ef9564f5fc64daL5-R5): Updated the version badge to reflect the new version `0.3.3`.

Credential handling improvements:
* [`charts/nocodb/templates/_helpers.tpl`](diffhunk://#diff-418d97319d8305d1fb0eb042f1faa1c7a072d87f99e2c1508b71fbbf1a4f1ebaL244-R253): Changed the key names for Minio credentials from `existingSecretRootUserKey` and `existingSecretRootPasswordKey` to `rootUserSecretKey` and `rootPasswordSecretKey`, respectively.