### PR TITLE
Add external MinIO configuration

### DIFF
--- a/charts/nocodb/Chart.yaml
+++ b/charts/nocodb/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.4
+version: 0.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/nocodb/Chart.yaml
+++ b/charts/nocodb/Chart.yaml
@@ -21,7 +21,7 @@ version: 0.4.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.257.0"
+appVersion: "0.257.2"
 
 dependencies:
   - condition: postgresql.enabled

--- a/charts/nocodb/README.md
+++ b/charts/nocodb/README.md
@@ -2,7 +2,7 @@
 
 
 
-![Version: 0.3.4](https://img.shields.io/badge/Version-0.3.4-informational?style=flat-square) 
+![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) 
 
 A Helm chart for Kubernetes
 
@@ -42,8 +42,8 @@ $ helm install my-release one-acre-fund/nocodb
 |-----|------|---------|-------------|
 | admin.create | bool | `true` |  |
 | admin.email | string | `""` |  |
+| admin.existingSecret | string | `""` |  |
 | admin.existingSecretEmailKey | string | `""` |  |
-| admin.existingSecretName | string | `""` |  |
 | admin.existingSecretPasswordKey | string | `""` |  |
 | admin.password | string | `""` |  |
 | affinity | object | `{}` |  |
@@ -82,6 +82,14 @@ $ helm install my-release one-acre-fund/nocodb
 | externalDatabase.postgresqlPostgresPassword | string | `""` |  |
 | externalDatabase.postgresqlPostgresUser | string | `"postgres"` |  |
 | externalDatabase.user | string | `"nocodb_user"` |  |
+| externalMinio.bucketName | string | `""` |  |
+| externalMinio.endpoint | string | `""` |  |
+| externalMinio.existingSecret | string | `""` |  |
+| externalMinio.region | string | `"us-east-1"` |  |
+| externalMinio.rootPassword | string | `""` |  |
+| externalMinio.rootPasswordSecretKey | string | `""` |  |
+| externalMinio.rootUser | string | `"admin"` |  |
+| externalMinio.rootUserSecretKey | string | `""` |  |
 | extraEnv | list | `[]` |  |
 | extraEnvSecrets | list | `[]` |  |
 | fullnameOverride | string | `""` |  |
@@ -92,7 +100,7 @@ $ helm install my-release one-acre-fund/nocodb
 | hostAliases | list | `[]` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"nocodb/nocodb"` |  |
-| image.tag | string | `"0.257.0"` |  |
+| image.tag | string | `"0.257.2"` |  |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` |  |
 | ingress.className | string | `""` |  |
@@ -180,7 +188,7 @@ $ helm install my-release one-acre-fund/nocodb
 | smtp.host | string | `"smtp.gmail.com"` |  |
 | smtp.ignoreTLS | bool | `true` |  |
 | smtp.password | string | `""` |  |
-| smtp.port | int | `587` |  |
+| smtp.port | int | `465` |  |
 | smtp.secure | bool | `true` |  |
 | smtp.username | string | `""` |  |
 | tolerations | list | `[]` |  |

--- a/charts/nocodb/templates/_helpers.tpl
+++ b/charts/nocodb/templates/_helpers.tpl
@@ -99,7 +99,7 @@ Return the Postgresql user
 {{/*
 Return the PostgreSQL Secret Name
 */}}
-{{- define "nocodb.databaseSecretName" -}}
+{{- define "nocodb.database.secretName" -}}
   {{- if .Values.postgresql.enabled }}
     {{- if .Values.postgresql.auth.existingSecret }}
       {{- tpl .Values.postgresql.auth.existingSecret $ -}}
@@ -114,9 +114,9 @@ Return the PostgreSQL Secret Name
 {{/*
 Add environment variables to configure database values
 */}}
-{{- define "nocodb.databaseSecretPasswordKey" -}}
+{{- define "nocodb.database.secretPasswordKey" -}}
 {{- if .Values.postgresql.enabled -}}
-    {{- print "password" -}}
+    {{- default "password" .Values.postgresql.auth.secretKeys.userPasswordKey -}}
 {{- else -}}
     {{- if .Values.externalDatabase.existingSecret -}}
         {{- if .Values.externalDatabase.existingSecretPasswordKey -}}
@@ -133,9 +133,9 @@ Add environment variables to configure database values
 {{/*
 Add environment variables to configure database values
 */}}
-{{- define "nocodb.databaseSecretPostgresPasswordKey" -}}
+{{- define "nocodb.database.secretPostgresPasswordKey" -}}
 {{- if .Values.postgresql.enabled -}}
-    {{- print "postgres-password" -}}
+    {{- default "postgres-password" .Values.postgresql.auth.secretKeys.postgresPasswordKey -}}
 {{- else -}}
     {{- if .Values.externalDatabase.existingSecret -}}
         {{- if .Values.externalDatabase.existingSecretPostgresPasswordKey -}}
@@ -161,29 +161,9 @@ Add environment variables to configure database values
 {{- end -}}
 
 
-{{- define "nocodb.jwtSecretName" -}}
-  {{- if .Values.jwt.existingSecretName -}}
-    {{- printf "%s" .Values.jwt.existingSecretName -}}
-  {{- else -}}
-    {{- if .Values.jwt.name -}}
-      {{- printf "%s" .Values.jwt.name -}}
-    {{- else -}}
-      {{- printf "%s-jwt-secret" (include "nocodb.fullname" .) -}}
-    {{- end -}}
-  {{- end -}}
-{{- end -}}
-
-{{- define "nocodb.jwtSecretKey" -}}
-    {{- if .Values.jwt.existingSecretKey -}}
-        {{- printf "%s" .Values.jwt.existingSecretKey -}}
-    {{- else -}}
-        {{- print "jwt-secret" -}}
-    {{- end -}}
-{{- end -}}
-
 {{- define "nocodb.admin.secretName" -}}
-  {{- if .Values.admin.existingSecretName -}}
-    {{- printf "%s" .Values.admin.existingSecretName -}}
+  {{- if .Values.admin.existingSecret -}}
+    {{- printf "%s" .Values.admin.existingSecret -}}
   {{- else -}}
     {{- printf "%s-supper-admin-secret" (include "nocodb.fullname" .) -}}
   {{- end -}}
@@ -206,8 +186,8 @@ Add environment variables to configure database values
 {{- end -}}
 
 {{- define "nocodb.smtp.secretName" -}}
-  {{- if .Values.smtp.existingSecretName -}}
-    {{- printf "%s" .Values.smtp.existingSecretName -}}
+  {{- if .Values.smtp.existingSecret -}}
+    {{- printf "%s" .Values.smtp.existingSecret -}}
   {{- else -}}
     {{- printf "%s-smtp-secret" (include "nocodb.fullname" .) -}}
   {{- end -}}

--- a/charts/nocodb/templates/deployment.yaml
+++ b/charts/nocodb/templates/deployment.yaml
@@ -90,8 +90,8 @@ spec:
             - name: NC_DB_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "nocodb.databaseSecretName" . }}
-                  key: {{ include "nocodb.databaseSecretPasswordKey" . }}
+                  name: {{ include "nocodb.database.secretName" . }}
+                  key: {{ include "nocodb.database.secretPasswordKey" . }}
             - name: PORT
               value: {{ .Values.service.ports.http | quote }}
             - name: NC_DB
@@ -111,11 +111,19 @@ spec:
               value: {{ .Values.minio.region | quote }}
             - name: NC_S3_BUCKET_NAME
               value: {{ include "nocodb.fullname" . | quote }}
+            {{- else }}
+            - name: NC_S3_ENDPOINT
+              value: {{ .Values.externalMinio.endpoint | quote }}
+            - name: NC_S3_REGION
+              value: {{ .Values.externalMinio.region | quote }}
+            - name: NC_S3_BUCKET_NAME
+              value: {{ .Values.externalMinio.bucketName | quote }}
+            {{- end }}
             - name: NC_S3_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
                   name: {{ include "nocodb.minio.secretName" . }}
-                  key: {{ include "nocodb.minio.rootPasswordKey" . }}
+                  key: {{ include "nocodb.minio.rootUserKey" . }}
             - name: NC_S3_ACCESS_SECRET
               valueFrom:
                 secretKeyRef:
@@ -123,7 +131,6 @@ spec:
                   key: {{ include "nocodb.minio.rootPasswordKey" . }}
             - name: NC_S3_FORCE_PATH_STYLE
               value: "true"
-            {{- end }}
             {{- if .Values.redis.enabled }}
             - name: NC_REDIS_PASSWORD
               valueFrom:
@@ -145,7 +152,7 @@ spec:
                   name: {{ include "nocodb.admin.secretName" . }}
                   key: {{ include "nocodb.admin.passwordKey" . }}
             {{- end }}
-            {{- if and .Values.smtp.enabled (or (not (eq .Values.smtp.password "")) .Values.smtp.existingSecretName) }}
+            {{- if .Values.smtp.enabled }}
             - name: NC_SMTP_HOST
               value: {{ .Values.smtp.host | quote }}
             - name: NC_SMTP_PORT
@@ -177,8 +184,8 @@ spec:
             - name: POSTGRESQL_CLIENT_POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "nocodb.databaseSecretName" . }}
-                  key: {{ include "nocodb.databaseSecretPostgresPasswordKey" . }}
+                  name: {{ include "nocodb.database.secretName" . }}
+                  key: {{ include "nocodb.database.secretPostgresPasswordKey" . }}
             - name: POSTGRESQL_CLIENT_CREATE_DATABASE_NAME
               value: {{ include "nocodb.databaseName" . }}
             - name: POSTGRESQL_CLIENT_CREATE_DATABASE_USERNAME
@@ -186,8 +193,8 @@ spec:
             - name: POSTGRESQL_CLIENT_CREATE_DATABASE_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "nocodb.databaseSecretName" . }}
-                  key: {{ include "nocodb.databaseSecretPasswordKey" . }}
+                  name: {{ include "nocodb.database.secretName" . }}
+                  key: {{ include "nocodb.database.secretPasswordKey" . }}
             {{- end }}
           envFrom:
             - secretRef:

--- a/charts/nocodb/templates/externalminio-secrets.yaml
+++ b/charts/nocodb/templates/externalminio-secrets.yaml
@@ -3,11 +3,11 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if not (or .Values.postgresql.enabled .Values.externalDatabase.existingSecret) }}
+{{- if not (or .Values.minio.enabled .Values.externalMinio.existingSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ printf "%s-externaldb" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
+  name: {{ printf "%s-externalminio" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
   {{- if .Values.commonAnnotations }}
@@ -15,6 +15,6 @@ metadata:
   {{- end }}
 type: Opaque
 data:
-  {{ include "nocodb.database.secretPasswordKey" . }}: {{ .Values.externalDatabase.password | b64enc | quote }}
-  {{ include "nocodb.database.secretPostgresPasswordKey" . }}: {{ .Values.externalDatabase.postgresqlPostgresPassword | b64enc | quote }}
+  {{ include "nocodb.minio.rootUserKey" . }}: {{ .Values.externalMinio.rootUser | b64enc | quote }}
+  {{ include "nocodb.minio.rootPasswordKey" . }}: {{ .Values.externalMinio.rootPassword | b64enc | quote }}
 {{- end }}

--- a/charts/nocodb/values.yaml
+++ b/charts/nocodb/values.yaml
@@ -20,7 +20,7 @@ nocodb:
 image:
   repository: nocodb/nocodb
   pullPolicy: IfNotPresent
-  tag: 0.257.0
+  tag: 0.257.2
 
 imagePullSecrets: []
 nameOverride: ""
@@ -261,12 +261,12 @@ admin:
   password: ""
   existingSecretPasswordKey: ""
   existingSecretEmailKey: ""
-  existingSecretName: ""
+  existingSecret: ""
 
 smtp:
   enabled: true
   host: smtp.gmail.com
-  port: 587
+  port: 465
   secure: true
   username: ""
   password: ""
@@ -286,6 +286,16 @@ minio:
     rootPasswordSecretKey: ""
   defaultBuckets: "nocodb"
   region: us-east-1
+
+externalMinio:
+  rootUser: admin
+  rootPassword: ""
+  endpoint: ""
+  region: us-east-1
+  bucketName: ""
+  existingSecret: ""
+  rootUserSecretKey: ""
+  rootPasswordSecretKey: ""
 
 redis:
   enabled: true


### PR DESCRIPTION
This pull request includes several updates to the Helm chart for NocoDB, focusing on version updates, configuration enhancements, and secret management improvements. The most important changes include version updates, added support for external Minio configuration, and refactoring of secret key references.

### Version Updates:
* Updated chart version to `0.4.0` in `charts/nocodb/Chart.yaml`.
* Updated image tag to `0.257.2` in `charts/nocodb/values.yaml`.

### Configuration Enhancements:
* Added support for external Minio configuration in `charts/nocodb/values.yaml` and `charts/nocodb/README.md` [[1]](diffhunk://#diff-9976709d7ce42fbee68b2bde1bd82250cdc88d71be79ea434de84e27f891ee91R290-R299) [[2]](diffhunk://#diff-730388c2f3d16c4d940391f1399dbe4edb2657881ccba39181ef9564f5fc64daR85-R92).
* Updated SMTP port to `465` in `charts/nocodb/values.yaml` and `charts/nocodb/README.md` [[1]](diffhunk://#diff-9976709d7ce42fbee68b2bde1bd82250cdc88d71be79ea434de84e27f891ee91L264-R269) [[2]](diffhunk://#diff-730388c2f3d16c4d940391f1399dbe4edb2657881ccba39181ef9564f5fc64daL183-R191).

### Secret Management Improvements:
* Refactored secret key references in `charts/nocodb/templates/_helpers.tpl` and `charts/nocodb/templates/deployment.yaml` [[1]](diffhunk://#diff-418d97319d8305d1fb0eb042f1faa1c7a072d87f99e2c1508b71fbbf1a4f1ebaL102-R102) [[2]](diffhunk://#diff-94600fa83e4adf02baa1f97ad0d29fb61a59707e2445890116187f6f72d4d896L93-R94).
* Added a new template for external Minio secrets in `charts/nocodb/templates/externalminio-secrets.yaml`.