### PR TITLE
feat(deployment): add init containers to wait for Minio and Redis readiness

### DIFF
--- a/charts/nocodb/Chart.yaml
+++ b/charts/nocodb/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.1
+version: 0.4.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/nocodb/README.md
+++ b/charts/nocodb/README.md
@@ -1,6 +1,6 @@
 # nocodb
 
-![Version: 0.4.1](https://img.shields.io/badge/Version-0.4.1-informational?style=flat-square) 
+![Version: 0.4.2](https://img.shields.io/badge/Version-0.4.2-informational?style=flat-square) 
 ![AppVersion: 0.257.2](https://img.shields.io/badge/AppVersion-0.257.2-informational?style=flat-square) 
 
 A Helm chart for Kubernetes

--- a/charts/nocodb/templates/deployment.yaml
+++ b/charts/nocodb/templates/deployment.yaml
@@ -54,10 +54,8 @@ spec:
       {{- if .Values.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       {{- end }}
-
-      # Init container to wait for the database
-      {{- if or .Values.postgresql.enabled .Values.externalDatabase.create }}
       initContainers:
+      {{- if or .Values.postgresql.enabled .Values.externalDatabase.create }}
         - name: wait-for-database
           image: postgres:alpine
           env:
@@ -78,6 +76,39 @@ spec:
                 sleep 2;
               done;
               echo "Database is ready.";
+      {{- end }}
+      {{- if or .Values.minio.enabled .Values.externalMinio.create }}
+        - name: wait-for-minio
+          image: busybox
+          command:
+            - sh
+            - -c
+            - |
+              until wget -qO- {{ include "nocodb.minio.endpoint" . }}/minio/health/ready; do
+                echo "Waiting for minio...";
+                sleep 2;
+              done;
+              echo "Minio is ready.";
+      {{- end }}
+      {{- if .Values.redis.enabled }}
+        - name: wait-for-redis
+          image: redis:alpine
+          env:
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "nocodb.redis.secretName" . }}
+                  key: {{ include "nocodb.redis.passwordKey" . }}
+          command:
+            - sh
+            - -c
+            - |
+              export REDISCLI_AUTH="$REDIS_PASSWORD"
+              until redis-cli -h "{{ include "nocodb.redis.fullname" . }}-master" -p "{{ .Values.redis.master.service.ports.redis }}" ping; do
+                echo "Waiting for redis...";
+                sleep 2;
+              done;
+              echo "Redis is ready.";
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}


### PR DESCRIPTION
This pull request includes several updates to the Helm chart for NocoDB, primarily focusing on version updates and enhancements to the deployment process. The most important changes include updating the chart version, adding init containers for Minio and Redis, and updating the README to reflect the new version.

### Version Updates:
* [`charts/nocodb/Chart.yaml`](diffhunk://#diff-41b537b84129195eaf7a36558c32b383f08d2acca8bcbc4a5ade6d226aa8ecfcL18-R18): Updated the chart version from `0.4.1` to `0.4.2`.
* [`charts/nocodb/README.md`](diffhunk://#diff-730388c2f3d16c4d940391f1399dbe4edb2657881ccba39181ef9564f5fc64daL3-R3): Updated the version badge from `0.4.1` to `0.4.2`.

### Deployment Enhancements:
* [`charts/nocodb/templates/deployment.yaml`](diffhunk://#diff-94600fa83e4adf02baa1f97ad0d29fb61a59707e2445890116187f6f72d4d896R80-R112): Added init containers to wait for Minio and Redis services to be ready before starting the main application container.
* [`charts/nocodb/templates/deployment.yaml`](diffhunk://#diff-94600fa83e4adf02baa1f97ad0d29fb61a59707e2445890116187f6f72d4d896L57-R58): Adjusted the existing init container logic for waiting on the database to be conditional based on configuration values.