### PR TITLE
Add environment variable references to Helm chart

### DIFF
--- a/charts/nocodb/Chart.yaml
+++ b/charts/nocodb/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.3
+version: 0.4.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/nocodb/README.md
+++ b/charts/nocodb/README.md
@@ -1,6 +1,6 @@
 # nocodb
 
-![Version: 0.4.3](https://img.shields.io/badge/Version-0.4.3-informational?style=flat-square) 
+![Version: 0.4.4](https://img.shields.io/badge/Version-0.4.4-informational?style=flat-square) 
 ![AppVersion: 0.257.2](https://img.shields.io/badge/AppVersion-0.257.2-informational?style=flat-square) 
 
 A Helm chart for Kubernetes

--- a/charts/nocodb/templates/deployment.yaml
+++ b/charts/nocodb/templates/deployment.yaml
@@ -220,6 +220,13 @@ spec:
                   name: {{ include "nocodb.database.secretName" . }}
                   key: {{ include "nocodb.database.secretPasswordKey" . }}
             {{- end }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "nocodb.fullname" . }}-config
+                optional: true
+            - secretRef:
+                name: {{ include "nocodb.fullname" . }}-secrets
+                optional: true
           ports:
             - name: http
               containerPort: {{ .Values.service.ports.http }}


### PR DESCRIPTION
Update the Helm chart to include references for environment variables from a ConfigMap and a Secret, and increment the chart version to 0.4.4.