### PR TITLE
chore(charts): bump nocodb version to 0.4.5 and app version to 0.258.0

### DIFF
--- a/charts/nocodb/Chart.yaml
+++ b/charts/nocodb/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.4
+version: 0.4.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.257.2"
+appVersion: "0.258.0"
 
 dependencies:
   - condition: postgresql.enabled

--- a/charts/nocodb/README.md
+++ b/charts/nocodb/README.md
@@ -1,7 +1,7 @@
 # nocodb
 
-![Version: 0.4.4](https://img.shields.io/badge/Version-0.4.4-informational?style=flat-square) 
-![AppVersion: 0.257.2](https://img.shields.io/badge/AppVersion-0.257.2-informational?style=flat-square) 
+![Version: 0.4.5](https://img.shields.io/badge/Version-0.4.5-informational?style=flat-square) 
+![AppVersion: 0.258.0](https://img.shields.io/badge/AppVersion-0.258.0-informational?style=flat-square) 
 
 A Helm chart for Kubernetes
 
@@ -98,7 +98,7 @@ helm install my-release one-acre-fund/nocodb
 | hostAliases | list | `[]` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"nocodb/nocodb"` |  |
-| image.tag | string | `"0.257.2"` |  |
+| image.tag | string | `"0.258.0"` |  |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` |  |
 | ingress.className | string | `""` |  |

--- a/charts/nocodb/values.yaml
+++ b/charts/nocodb/values.yaml
@@ -20,7 +20,7 @@ nocodb:
 image:
   repository: nocodb/nocodb
   pullPolicy: IfNotPresent
-  tag: 0.257.2
+  tag: 0.258.0
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
This pull request includes updates to the version numbers for the NocoDB Helm chart and its application. The changes ensure that the documentation and configuration files reflect the new version.

Version updates:

* [`charts/nocodb/Chart.yaml`](diffhunk://#diff-41b537b84129195eaf7a36558c32b383f08d2acca8bcbc4a5ade6d226aa8ecfcL18-R24): Updated the chart version to `0.4.5` and the app version to `0.258.0`.
* [`charts/nocodb/README.md`](diffhunk://#diff-730388c2f3d16c4d940391f1399dbe4edb2657881ccba39181ef9564f5fc64daL3-R4): Updated the version badges to `0.4.5` for the chart and `0.258.0` for the app.
* [`charts/nocodb/README.md`](diffhunk://#diff-730388c2f3d16c4d940391f1399dbe4edb2657881ccba39181ef9564f5fc64daL101-R101): Updated the `image.tag` to `0.258.0` in the installation command example.
* [`charts/nocodb/values.yaml`](diffhunk://#diff-9976709d7ce42fbee68b2bde1bd82250cdc88d71be79ea434de84e27f891ee91L23-R23): Updated the `image.tag` to `0.258.0`.