### PR TITLE
Add imagePullSecrets to values.yaml file

### DIFF
--- a/charts/growthbook/values.yaml
+++ b/charts/growthbook/values.yaml
@@ -9,6 +9,8 @@ image:
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
   tag: latest
+imagePullSecrets: []
+  # - name: some-pull-secret
 
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
# Proposed changes

This pull request contains a minor update to the `charts/growthbook/values.yaml` file. The update includes the addition of `imagePullSecrets` to the `values.yaml` file. `imagePullSecrets` has been used in the deployment.yaml file within the templates folder, but it has not yet been added to the `values.yml` file.

## Checklist

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support for specifying image pull secrets in Helm chart configuration
	- Enabled authentication for private container registry image pulls
<!-- end of auto-generated comment: release notes by coderabbit.ai -->