### PR TITLE
[MID-1303] Upgrade Growthbook chart from v2.0.0 to v3.4.0

### DIFF
--- a/charts/growthbook/Chart.yaml
+++ b/charts/growthbook/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.16
+version: 0.1.17
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.16.0"
+appVersion: "3.4.0"
 
 icon: https://cdn.svgporn.com/logos/growth-book-icon.svg
 

--- a/charts/growthbook/README.md
+++ b/charts/growthbook/README.md
@@ -1,6 +1,6 @@
 # growthbook
 
-![Version: 0.1.16](https://img.shields.io/badge/Version-0.1.16-informational?style=flat-square)
+![Version: 0.1.17](https://img.shields.io/badge/Version-0.1.17-informational?style=flat-square)
 
 A Helm chart for Growthbook
 
@@ -63,7 +63,7 @@ $ helm install my-release one-acre-fund/growthbook
 | growthbook.sso.ssoConfig | object | `{}` |  |
 | image.pullPolicy | string | `"Always"` |  |
 | image.repository | string | `"growthbook/growthbook"` |  |
-| image.tag | string | `"latest"` |  |
+| image.tag | string | `"3.4.0"` |  |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations."kubernetes.io/ingress.class" | string | `"nginx"` |  |
 | ingress.annotations."nginx.ingress.kubernetes.io/cors-allow-headers" | string | `"Authorization,Referer,sec-ch-ua,sec-ch-ua-mobile,sec-ch-ua-platform,User-Agent,X-Organization,Content-Type"` |  |

--- a/charts/growthbook/values.yaml
+++ b/charts/growthbook/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: growthbook/growthbook
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
-  tag: latest
+  tag: "3.4.0"
 imagePullSecrets: []
   # - name: some-pull-secret
 


### PR DESCRIPTION
# Proposed changes
Upgrading Growthbook from v2.0.0 to v3.4.0 to leverage the latest features and improvements. This change updates the container image version in the Helm chart and increments the chart version from 0.1.16 to 0.1.17.

## Checklist
- [x] I have added documentation to describe my changes.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information
This upgrade requires careful deployment with database backup prior to upgrading. Database migrations will run automatically during the container startup.

Key files changed:
- `Chart.yaml`: Updated chart version to 0.1.17 and appVersion to 3.4.0
- `values.yaml`: Updated image tag to 3.4.0
- `README.md`: Updated version information

Related JIRA ticket: MID-1303

## Deployment Instructions
```bash
# BACKUP (before upgrade)
# Backup MongoDB
kubectl exec -n tools $(kubectl get pods -n tools -l app.kubernetes.io/name=mongodb,app.kubernetes.io/instance=growthbook -o jsonpath='{.items[0].metadata.name}') -- mongodump --out=/tmp/growthbook-backup-$(date +%Y%m%d) --db=growthbook

# Backup current Helm values
helm get values growthbook -n tools -o yaml > growthbook-values-backup.yaml

# UPGRADE
# Update Helm repositories
helm repo update

# Apply the upgrade
helm upgrade growthbook one-acre-fund/growthbook -n tools

# Monitor the deployment
kubectl get pods -n tools -l app.kubernetes.io/name=growthbook -w
kubectl logs -n tools -l app.kubernetes.io/name=growthbook

# ROLLBACK (if needed)
# Rollback to previous release
helm rollback growthbook -n tools

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the Helm chart configuration to use the new release version with a specific application version, ensuring deployments use a consistent image.
- **Documentation**
  - Refreshed version indicators in the documentation to reflect the new release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->