### PR TITLE
fix(apicurio): use postgresql.auth.* keys for Bitnami subchart v11.x

### DIFF
--- a/charts/apicurio/Chart.yaml
+++ b/charts/apicurio/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: apicurio
-version: 2.1.0
+version: 2.2.0
 appVersion: "0.2.62.Final"
 description: Apicurio Studio API designer
 icon: https://avatars.githubusercontent.com/u/28107283?s=400&v=4

--- a/charts/apicurio/ci/ci-values.yaml
+++ b/charts/apicurio/ci/ci-values.yaml
@@ -5,15 +5,3 @@ keycloak:
   client:
     id: apicurio-studio
     secret: apicuriokc
-
-microcks:
-  enabled: true
-  client:
-    secret: testmicrocksecret
-  secrets:
-    mongodb:
-      mongodb-passwords: testpass
-      mongodb-root-password: testrootpass
-
-postgresql:
-  postgresqlPassword: testdbpass

--- a/charts/apicurio/templates/_helpers.tpl
+++ b/charts/apicurio/templates/_helpers.tpl
@@ -1,7 +1,7 @@
 {{/* ---- Apicurio Studio helpers ---- */}}
 
 {{ define "secrets_api" -}}
-APICURIO_DB_PASSWORD: {{ .Values.postgresql.postgresqlPassword | b64enc }}
+APICURIO_DB_PASSWORD: {{ .Values.postgresql.auth.password | b64enc }}
 {{- if .Values.keycloak.enabled }}
 APICURIO_KC_CLIENT_SECRET: {{ .Values.keycloak.client.secret | b64enc }}
 {{- end }}
@@ -29,7 +29,7 @@ APICURIO_MICROCKS_CLIENT_SECRET: {{ .Values.microcks.client.secret | b64enc }}
 {{- end }}
 
 {{ define "secrets_ws" -}}
-APICURIO_DB_PASSWORD: {{ .Values.postgresql.postgresqlPassword | b64enc }}
+APICURIO_DB_PASSWORD: {{ .Values.postgresql.auth.password | b64enc }}
 # Extras
 {{- range $key, $value := .Values.ws.extraSecretEnvVars }}
 {{ $key }}: {{- tpl $value $ | b64enc }}
@@ -41,7 +41,7 @@ APICURIO_DB_PASSWORD: {{ .Values.postgresql.postgresqlPassword | b64enc }}
 {{- end -}}
 
 {{- define "dbUrl" -}}
-{{ printf "jdbc:postgresql://%s:%s/%s" (include "dbHost" .) ( toString .Values.postgresql.service.port ) .Values.postgresql.postgresqlDatabase }}
+{{ printf "jdbc:postgresql://%s:%s/%s" (include "dbHost" .) ( toString .Values.postgresql.service.port ) .Values.postgresql.auth.database }}
 {{- end -}}
 
 {{- define "tcpProbe" -}}

--- a/charts/apicurio/templates/apicurio-studio-api-deployment.yaml
+++ b/charts/apicurio/templates/apicurio-studio-api-deployment.yaml
@@ -49,7 +49,7 @@ spec:
             - name: APICURIO_DB_TYPE
               value: {{ .Values.database.type | quote }}
             - name: APICURIO_DB_USER_NAME
-              value: {{ .Values.postgresql.postgresqlUsername | quote }}
+              value: {{ .Values.postgresql.auth.username | quote }}
 
             {{- if or .Values.microcks.enabled .Values.microcks.client.apiUrl }}
             # Microcks settings

--- a/charts/apicurio/templates/apicurio-studio-ws-deployment.yaml
+++ b/charts/apicurio/templates/apicurio-studio-ws-deployment.yaml
@@ -51,7 +51,7 @@ spec:
             - name: APICURIO_DB_TYPE
               value: {{ .Values.database.type | quote }}
             - name: APICURIO_DB_USER_NAME
-              value: {{ .Values.postgresql.postgresqlUsername | quote }}
+              value: {{ .Values.postgresql.auth.username | quote }}
 
             # Others
             - name: APICURIO_SHARE_FOR_EVERYONE

--- a/charts/apicurio/values.yaml
+++ b/charts/apicurio/values.yaml
@@ -160,12 +160,13 @@ postgresql:
     repository: bitnamilegacy/postgresql
   # -- Custom db host name if not using the subchart
   host: null
-  # -- Apicurio DB name
-  postgresqlDatabase: apicuriodb
-  # -- Apicurio DB user
-  postgresqlUsername: apicuriodb
-  # -- Apicurio DB user password
-  postgresqlPassword: ""
+  auth:
+    # -- Apicurio DB user
+    username: apicuriodb
+    # -- Apicurio DB user password
+    password: ""
+    # -- Apicurio DB name
+    database: apicuriodb
   service:
     # -- postgres port
     port: 5432


### PR DESCRIPTION
# Proposed changes

Bitnami postgresql v11.6.x uses `auth.username`, `auth.password`, `auth.database` instead of the legacy `postgresqlUsername`, `postgresqlPassword`, `postgresqlDatabase` keys. The old keys were only read by Apicurio chart templates but ignored by the Bitnami subchart, causing the `apicuriodb` DB user to never be created during PostgreSQL initialization — resulting in `password authentication failed for user "apicuriodb"` errors.

Changes:
- Updated `values.yaml` to use `postgresql.auth.*` keys
- Updated `_helpers.tpl` and deployment templates to reference the new keys
- Cleaned up `ci-values.yaml`
- Bumped chart version to `2.2.0`

## Checklist

- [x] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information

This is a breaking change for users who were setting `postgresql.postgresqlPassword` directly. They should now use `postgresql.auth.password` instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Helm chart version incremented to 2.2.0
  * Removed unused service configurations from CI environment setup

* **Refactor**
  * Restructured PostgreSQL authentication parameters in Helm configuration to use a new nested path structure
  * Updated API and WebSocket deployment configurations to reference the updated PostgreSQL credential locations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->